### PR TITLE
auto-restart if container command changes

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'sysadmin@socrata.com'
 license          'All rights reserved'
 description      'LWRP for running a docker container via runit'
 long_description 'LWRP for running a docker container via runit'
-version          '0.3.0'
+version          '0.3.1'
 
 depends          'runit'
 depends          'docker-legacy'

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -50,21 +50,17 @@ action :create do
     ].join(' ')
   end
 
-  ruby_block "enable-#{new_resource.name}" do
-    block do
-      Chef::Log.debug("Enabling #{new_resource.name}")
-    end
-    notifies :enable, runit, :delayed
-  end
-
-  ruby_block "start-#{new_resource.name}" do
-    block do
-      Chef::Log.debug("Starting #{new_resource.name}")
-    end
-    notifies :start, runit, :delayed
-  end
-
   new_resource.updated_by_last_action(runit.updated_by_last_action?)
+
+  if new_resource.updated_by_last_action?
+    ruby_block "restart-#{new_resource.name}" do
+      block do
+        Chef::Log.debug("Restarting #{new_resource.name}")
+      end
+      notifies :restart, runit, :immediately
+    end
+  end
+
 end
 
 action :remove do


### PR DESCRIPTION
Prior to this, if the command changed, nothing happened and the service would have to be manually restarted. Going forward, the new command will be "released" immediately. This means we will want to chef-lock nodes before updating.
